### PR TITLE
Use watchdog for real-time media uploads

### DIFF
--- a/watcher.py
+++ b/watcher.py
@@ -1,0 +1,17 @@
+from watchdog.events import FileSystemEventHandler
+import os
+
+
+class Watcher(FileSystemEventHandler):
+    """Handles filesystem events for new media files."""
+
+    def __init__(self, uploader):
+        self.uploader = uploader
+
+    def on_created(self, event):
+        if event.is_directory:
+            return
+        _, ext = os.path.splitext(event.src_path)
+        if ext.lower() in self.uploader.media_extensions:
+            self.uploader._upload_media(event.src_path)
+


### PR DESCRIPTION
## Summary
- watch for new media files with a `Watcher` subclass of `FileSystemEventHandler`
- replace polling loop by scheduling an `Observer` for each folder and using callbacks

## Testing
- `python -m py_compile 420senderWeed.py watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa90b0e90c83259fd8b2c0a1819477